### PR TITLE
Add optional opts parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@ var elixir = require('laravel-elixir');
 var utilities = require('laravel-elixir/ingredients/commands/Utilities');
 var $ = require('gulp-load-plugins')();
 
-elixir.extend('useref', function(config) {
+elixir.extend('useref', function(config, opts) {
 
 	var config = config || {};
+	var opts = opts || {};
 
 	config.baseDir = config.baseDir || 'resources/views';
 	config.src = 'src' in config ? config.src : 'app.blade.php';
@@ -16,7 +17,7 @@ elixir.extend('useref', function(config) {
 
 	gulp.task('useref', function() {
 
-		var assets = $.useref.assets();
+		var assets = $.useref.assets(opts);
 
 		return gulp.src(src)
 			.pipe(assets)


### PR DESCRIPTION
I found it useful to have the ability to pass options straight through to the useref assets call.

This should add it succesfully. There aren't many options but the one I needed was [`searchPath`](https://github.com/jonkemp/gulp-useref#optionssearchpath)

This allowed me to allow it to search for assets in the public folder, where I had put the pre compiled not yet production ready files.
