### PR TITLE
Add options to disable js and css minimization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ These are the default wrapper options:
 {
     baseDir: 'resources/views', // the folder for your views
     src: 'app.blade.php', // file to search, false to scan
-    searchLevel: '**/*.php' //How many search levels you want
+    searchLevel: '**/*.php', //How many search levels you want
+    minifyJs: true, //If you want to minimise the js files
+    minifyCss: true //If you want to minimise the css files
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var gulp = require('gulp');
 var Elixir = require('laravel-elixir');
+var util = require('gulp-util');
 var $ = require('gulp-load-plugins')();
 
 var Task = Elixir.Task;
@@ -14,6 +15,8 @@ Elixir.extend('useref', function(config, opts) {
     config.src = config.src || false;
     config.searchLevel = config.searchLevel || '**/*.php';
     config.outputDir = config.outputDir || 'public';
+    config.minifyJs = 'minifyJs' in config ? !!config.minifyJs : true;
+    config.minifyCss = 'minifyCss' in config ? !!config.minifyCss : true;
 
     new Task('useref', function() {
 
@@ -22,8 +25,8 @@ Elixir.extend('useref', function(config, opts) {
 
         return gulp.src(src)
             .pipe(assets)
-            .pipe($.if('*.js', $.uglify()))
-            .pipe($.if('*.css', $.csso()))
+            .pipe(config.minifyJs ? $.if('*.js', $.uglify()) : util.noop())
+            .pipe(config.minifyCss ? $.if('*.css', $.csso()) : util.noop())
             .pipe(gulp.dest(config.outputDir))
             .pipe($.size());
     });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-size": "^1.2.0",
     "gulp-uglify": "^1.1.0",
-    "gulp-useref": "^1.1.1"
+    "gulp-useref": "^1.1.1",
+    "gulp-util": "^3.0.7"
   }
 }


### PR DESCRIPTION
As I had troubles with Uglify and some Angular libraries, I added options to disable js or css minimization (or both), this way already minified libraries can be used without useless, slow and dangerous re-minification.