### PR TITLE
Upgraded gulp-if version to ^2.0 as the old one use a version of gulp-match which is incompatible with recent node versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/morrislaptop/laravel-elixir-useref",
   "dependencies": {
     "gulp-csso": "^1.0.0",
-    "gulp-if": "^1.2.5",
+    "gulp-if": "^2.0",
     "gulp-load-plugins": "^0.8.0",
     "gulp-size": "^1.2.0",
     "gulp-uglify": "^1.1.0",


### PR DESCRIPTION
The old version of gulp-match used by gulp-if 1.x doesn't work on recent versions of node (at least versions >= 6) because it can't detect if an object is a RegExp (look at its code for better understanding).
The new version has no problems and I didn't find any incompatibility with the rest of the components.